### PR TITLE
Extend statemachine with dynamic menus

### DIFF
--- a/TiKiTuTo/Controller/AppState.cs
+++ b/TiKiTuTo/Controller/AppState.cs
@@ -6,11 +6,14 @@ namespace TiKiTuTo.Controller
     {
         MainMenu,
         StartTournamentMenu,
-        ManageSettingsMenu,
         ShowSavedTournaments,
         ShowFinishedTournaments,
-        ShowAvailableTournamentSettings,
+        ManageSettingsMenu,
+        TournamentSettingsCreationDialogue,
+        ShowLoadableTournamentSettings,
         RunTournament,
+        ShowEditableTournamentSettings,
+        TournamentSettingsEditingDialogue,
         Exit
     } 
 }

--- a/TiKiTuTo/Controller/Controller.cs
+++ b/TiKiTuTo/Controller/Controller.cs
@@ -46,10 +46,10 @@ namespace TiKiTuTo.Controller
         {
             while (_stateMachine.CurrentState != AppState.Exit)
             {
-                _stateMachine.ExecuteCurrentState();
-                int userChoice = InputHandler.GetValidMenuInput();
+                int userChoice = _stateMachine.ExecuteCurrentState();
                 _stateMachine.HandleInput(userChoice);
             }
+            Environment.Exit(0);
         }
 
 

--- a/TiKiTuTo/Controller/StateMachine.cs
+++ b/TiKiTuTo/Controller/StateMachine.cs
@@ -68,7 +68,9 @@ namespace TiKiTuTo.Controller
                     return _view.StartTournamentMenuSelection();
                     break;
                 case AppState.ShowSavedTournaments:
-                    _view.ShowMessage("Saved tournaments (not implemented yet).");
+                    //_view.ShowMessage("Saved tournaments (not implemented yet).");
+                    List<string> loadableFiles = _jsonService.GetUnfinishedTournamentFiles();
+                    return _view.SavedTournamentsSelection(loadableFiles);
                     break;
                 case AppState.ShowFinishedTournaments:
                     _view.ShowMessage("Finished tournaments (not implemented yet).");
@@ -102,6 +104,7 @@ namespace TiKiTuTo.Controller
                     _view.ShowMessage("Not a valid state.");
                     break;
             }
+            //base case for states where the user decides to stay in the current context (no state transition)
             return 0;
         }
 
@@ -185,7 +188,7 @@ namespace TiKiTuTo.Controller
             switch (choice)
             {
                 case 1:
-                    TransitionTo(AppState.StartTournamentMenu);                  
+                    TransitionTo(AppState.StartTournamentMenu);
                     break;
                 case 2:
                     TransitionTo(AppState.ShowSavedTournaments);
@@ -214,7 +217,8 @@ namespace TiKiTuTo.Controller
             switch (choice)
             {
                 case 1:
-                    TransitionTo(AppState.TournamentSettingsCreationDialogue);
+                    //TransitionTo(AppState.TournamentSettingsCreationDialogue);
+                    TransitionTo(AppState.RunTournament);
                     break;
                 case 2:
                     TransitionTo(AppState.ShowLoadableTournamentSettings);
@@ -258,7 +262,7 @@ namespace TiKiTuTo.Controller
         /// <param name="choice">user input</param>
         private void HandleShowSavedTournamentsChoice(int choice)
         {
-            List<string> unfinishedTournamentFiles = JSONService.GetUnfinishedTournamentFiles();
+            List<string> unfinishedTournamentFiles = _jsonService.GetUnfinishedTournamentFiles();
             if (choice <= unfinishedTournamentFiles.Count) //a valid tournament file
             {
                 string chosenTournament = unfinishedTournamentFiles[choice];
@@ -284,7 +288,7 @@ namespace TiKiTuTo.Controller
         /// <param name="choice">user input</param>
         private void HandleShowFinishedTournamentsChoice(int choice)
         {
-            List<string> unfinishedTournamentFiles = JSONService.GetFinishedTournamentFiles();
+            List<string> unfinishedTournamentFiles = _jsonService.GetFinishedTournamentFiles();
             if (choice <= unfinishedTournamentFiles.Count) //a valid tournament file
             {
                 string chosenTournament = unfinishedTournamentFiles[choice];

--- a/TiKiTuTo/Controller/StateMachine.cs
+++ b/TiKiTuTo/Controller/StateMachine.cs
@@ -55,15 +55,17 @@ namespace TiKiTuTo.Controller
         //InGameMenu  TODO
         //Exit  TODO
 
-        public void ExecuteCurrentState()
+        public int ExecuteCurrentState()
         {
             switch (CurrentState)
             {
                 case AppState.MainMenu:
-                    _view.ShowMainMenu();
+                    //_view.ShowMainMenu();
+                    return _view.MainMenuSelection();
                     break;
                 case AppState.StartTournamentMenu:
-                    _view.ShowStartTournamentMenu();
+                    //_view.ShowStartTournamentMenu();
+                    return _view.StartTournamentMenuSelection();
                     break;
                 case AppState.ShowSavedTournaments:
                     _view.ShowMessage("Saved tournaments (not implemented yet).");
@@ -100,6 +102,7 @@ namespace TiKiTuTo.Controller
                     _view.ShowMessage("Not a valid state.");
                     break;
             }
+            return 0;
         }
 
 

--- a/TiKiTuTo/Controller/StateMachine.cs
+++ b/TiKiTuTo/Controller/StateMachine.cs
@@ -9,15 +9,21 @@ namespace TiKiTuTo.Controller
     {
         public AppState CurrentState { get; private set; }
         private readonly IView _view;
+        private JSONService _jsonService;
+        private Model.Model _model;
 
 
         /// <summary>
-        /// StateMachine constructor. Starts from the main menu by default
+        /// StateMachine constructor. Starts from the main menu by default.
         /// </summary>
-        public StateMachine(IView view)
+        /// <param name="view">A view used to render for different states.</param>
+        public StateMachine(IView view, JSONService jsonService, Model.Model model)
         {
             CurrentState = AppState.MainMenu;
             _view = view;
+            _jsonService = jsonService;
+            _model = model;
+
         }
 
 
@@ -29,6 +35,14 @@ namespace TiKiTuTo.Controller
         }
 
 
+
+
+
+
+        /// <summary>
+        /// A wrapper to handle user input for different internal states.
+        /// </summary>
+        /// <param name="choice">User input</param>
         public void HandleInput(int choice)
         {
             switch (CurrentState)
@@ -39,10 +53,61 @@ namespace TiKiTuTo.Controller
                 case AppState.StartTournamentMenu:
                     HandleStartTournamentMenuChoice(choice);
                     break;
-                    // Add handling for other states...
+                case AppState.ShowSavedTournaments:
+                    HandleShowSavedTournamentsChoice(choice);
+                    break;
+                case AppState.ShowFinishedTournaments:
+                    HandleShowFinishedTournamentsChoice(choice);
+                    break;
+                case AppState.ManageSettingsMenu:
+                    HandleManageSettingsMenuChoice(choice);
+                    break;
+                case AppState.TournamentSettingsCreationDialogue:
+                    HandleTournamentSettingsCreationDialogueChoice(choice);
+                    break;
+                case AppState.ShowLoadableTournamentSettings:
+                    HandleShowLoadableTournamentSettingsChoice(choice);
+                    break;
+                case AppState.ShowLoadableTournamentSettings:
+                    HandleShowLoadableTournamentSettingsChoice(choice);
+                    break;
+                case AppState.RunTournament:
+                    HandleRunTournamentChoice(choice);
+                    break;
+                case AppState.ShowEditableTournamentSettings:
+                    HandleShowEditableTournamentSettingsChoice(choice);
+                    break;
+                case AppState.TournamentSettingsEditingDialogue:
+                    HandleTournamentSettingsEditingDialogueChoice(choice);
+                    break;
+                case AppState.Exit:
+                    HandleExitChoice(choice);
+                    break;
             }
         }
 
+
+
+        //MainMenu,
+        //StartTournamentMenu,
+        //ShowSavedTournaments,
+        //ShowFinishedTournaments,
+        //ManageSettingsMenu,
+        TournamentSettingsCreationDialogue,
+        ShowLoadableTournamentSettings,
+        RunTournament,
+        ShowEditableTournamentSettings,
+        TournamentSettingsEditingDialogue,
+        Exit
+
+
+
+
+
+        /// <summary>
+        /// Handles transitions from the main menu based on user input.
+        /// </summary>
+        /// <param name="choice">User input</param>
         private void HandleMainMenuChoice(int choice)
         {
             switch (choice)
@@ -69,16 +134,19 @@ namespace TiKiTuTo.Controller
             }
         }
 
-
+        /// <summary>
+        /// Handles transitions from the StartTournament menu based on user input.
+        /// </summary>
+        /// <param name="choice">user input</param>
         private void HandleStartTournamentMenuChoice(int choice)
         {
             switch (choice)
             {
                 case 1:
-                    TransitionTo(AppState.RunTournament);
+                    TransitionTo(AppState.TournamentSettingsCreationDialogue);
                     break;
                 case 2:
-                    TransitionTo(AppState.ShowAvailableTournamentSettings);
+                    TransitionTo(AppState.ShowLoadableTournamentSettings);
                     break;
                 case 3:
                     TransitionTo(AppState.MainMenu);
@@ -89,12 +157,87 @@ namespace TiKiTuTo.Controller
             }
         }
 
-/*        private void HandelRunTournamentChoice(int choice)
+        /// <summary>
+        /// Handles transitions from the ManageSettings menu based on user input.
+        /// </summary>
+        /// <param name="choice">user input</param>
+        private void HandleManageSettingsMenuChoice(int choice)
+        {
+            switch (choice)
+            {
+                case 1:
+                    TransitionTo(AppState.TournamentSettingsCreationDialogue);
+                    break;
+                case 2:
+                    TransitionTo(AppState.ShowEditableTournamentSettings);
+                    break;
+                case 3:
+                    TransitionTo(AppState.MainMenu);
+                    break;
+                default:
+                    _view.ShowInvalidInputMessage();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Handles transitions from the ShowSavedTournaments menu based on user input.
+        /// The number of valid options depends on the number of unfinished tournaments found in the savegame folder.
+        /// </summary>
+        /// <param name="choice">user input</param>
+        private void HandleShowSavedTournamentsChoice(int choice)
+        {
+            List<string> unfinishedTournamentFiles = JSONService.GetUnfinishedTournamentFiles();
+            if (choice <= unfinishedTournamentFiles.Count) //a valid tournament file
+            {
+                string chosenTournament = unfinishedTournamentFiles[choice];
+                _view.ShowMessage($"Opening {chosenTournament}");
+                _model.Tournament = _jsonService.LoadGame(chosenTournament);
+                TransitionTo(AppState.RunTournament);
+            }
+            else if (choice == unfinishedTournamentFiles.Count + 1) //back to main menu
+            {
+                TransitionTo(AppState.MainMenu);
+            }
+            else //not a valid input
+            {
+                _view.ShowInvalidInputMessage();
+            }
+        }
+
+
+        /// <summary>
+        /// Handles transitions from the ShowFinishedTournaments menu based on user input.
+        /// The number of valid options depends on the number of unfinished tournaments found in the savegame folder.
+        /// </summary>
+        /// <param name="choice">user input</param>
+        private void HandleShowFinishedTournamentsChoice(int choice)
+        {
+            List<string> unfinishedTournamentFiles = JSONService.GetFinishedTournamentFiles();
+            if (choice <= unfinishedTournamentFiles.Count) //a valid tournament file
+            {
+                string chosenTournament = unfinishedTournamentFiles[choice];
+                _view.ShowMessage($"Opening {chosenTournament}");
+                TransitionTo(AppState.RunTournament);
+            }
+            else if (choice == unfinishedTournamentFiles.Count + 1) //back to main menu
+            {
+                TransitionTo(AppState.MainMenu);
+            }
+            else //not a valid input
+            {
+                _view.ShowInvalidInputMessage();
+            }
+
+        }
+
+        private void HandleRunTournamentChoice(int choice)
         {
 
         }
-*/
 
+
+        //TODO: HandleShowAvailableTournamentSettingsChoice (variable number of valid options...)
 
     }
-}
+    }

--- a/TiKiTuTo/Controller/StateMachine.cs
+++ b/TiKiTuTo/Controller/StateMachine.cs
@@ -79,13 +79,12 @@ namespace TiKiTuTo.Controller
                     _view.ShowMessage("Settings menu (not implemented yet).");
                     break;
                 case AppState.TournamentSettingsCreationDialogue:
-                    _view.ShowMessage("TournamentSettingsCreationDialogue (not implemented yet).");
+                    _gameLogicTournament.InitTournament();
                     break;
                 case AppState.ShowLoadableTournamentSettings:
                     _view.ShowMessage("ShowLoadableTournamentSettings (not implemented yet).");
                     break;
                 case AppState.RunTournament:
-                    _gameLogicTournament.InitTournament();
                     _gameLogicTournament.StartTournament();
                     break;
                 case AppState.ShowEditableTournamentSettings:
@@ -152,7 +151,7 @@ namespace TiKiTuTo.Controller
                     //HandleTournamentSettingsEditingDialogueChoice(choice);
                     break;
                 case AppState.InGameMenu:
-                    //HandleInGameMenuChoice(choice);
+                    HandleInGameMenuChoice(choice);
                     break;
                 case AppState.Exit:
                     //HandleExitChoice(choice);
@@ -308,9 +307,42 @@ namespace TiKiTuTo.Controller
 
         private void HandleRunTournamentChoice(int choice)
         {
-
+            switch (choice)
+            {
+                case 1:
+                    TransitionTo(AppState.TournamentSettingsCreationDialogue);
+                    break;
+                case 2:
+                    TransitionTo(AppState.ShowEditableTournamentSettings);
+                    break;
+                case 3:
+                    TransitionTo(AppState.MainMenu);
+                    break;
+                default:
+                    _view.ShowInvalidInputMessage();
+                    break;
+            }
         }
 
+        private void HandleInGameMenuChoice(int choice)
+        {
+            switch (choice)
+            {
+                case 1:
+                    _jsonService.SaveGame();
+                    break;
+                case 2:
+                    TransitionTo(AppState.MainMenu);
+                    break;
+                case 3:
+                    _jsonService.SaveGame();
+                    TransitionTo(AppState.Exit);
+                    break;
+                default:
+                    _view.ShowInvalidInputMessage();
+                    break;
+            }
+        }
 
         //TODO: HandleShowAvailableTournamentSettingsChoice (variable number of valid options...)
 

--- a/TiKiTuTo/JSONService.cs
+++ b/TiKiTuTo/JSONService.cs
@@ -78,5 +78,23 @@ namespace TiKiTuTo.Controller
             }
         }
 
+        /// <summary>
+        /// Returns all files containing unfinished tournaments (ready to be continued)
+        /// </summary>
+        /// <returns> List<string> of file names for the tournament JSON files.</returns>
+        public static List<string> GetUnfinishedTournamentFiles()
+        {
+            return new List<string>();
+        }
+
+        /// <summary>
+        /// Returns all files containing finished tournaments (ready to show results)
+        /// </summary>
+        /// <returns> List<string> of file names for the tournament JSON files.</returns>
+        public static List<string> GetFinishedTournamentFiles()
+        {
+            return new List<string>();
+        }
+
     }
 }

--- a/TiKiTuTo/JSONService.cs
+++ b/TiKiTuTo/JSONService.cs
@@ -142,16 +142,20 @@ namespace TiKiTuTo.Controller
         /// Returns all files containing unfinished tournaments (ready to be continued)
         /// </summary>
         /// <returns> List<string> of file names for the tournament JSON files.</returns>
-        public static List<string> GetUnfinishedTournamentFiles()
+        public List<string> GetUnfinishedTournamentFiles()
         {
-            return new List<string>();
+            return new List<string>() 
+            { 
+                "testfile1",
+                "testfile2"
+            };
         }
 
         /// <summary>
         /// Returns all files containing finished tournaments (ready to show results)
         /// </summary>
         /// <returns> List<string> of file names for the tournament JSON files.</returns>
-        public static List<string> GetFinishedTournamentFiles()
+        public List<string> GetFinishedTournamentFiles()
         {
             return new List<string>();
         }

--- a/TiKiTuTo/JSONService.cs
+++ b/TiKiTuTo/JSONService.cs
@@ -79,6 +79,65 @@ namespace TiKiTuTo.Controller
             }
         }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+///space for Dominiks JSON magic
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
         /// <summary>
         /// Returns all files containing unfinished tournaments (ready to be continued)
         /// </summary>

--- a/TiKiTuTo/Program.cs
+++ b/TiKiTuTo/Program.cs
@@ -10,13 +10,12 @@ namespace TiKiTuTo.Controller
     {
         public static void Main()
         {
-
+            Model.Model model = new();
+            JSONService json = new JSONService(model);
             IView view = new ConsoleView();
             InputValidator inputValidator = new InputValidator();
             InputHandler inputHandler = new InputHandler(view, inputValidator);
-            StateMachine stateMachine = new StateMachine(view);
-            Model.Model model = new();
-            JSONService json = new JSONService(model);
+            StateMachine stateMachine = new StateMachine(view, json, model);
             GameLogicMatch gameLogicMatch = new(inputHandler, json);
             GameLogicRound gameLogicRound = new(inputHandler, json);
             GameLogicTournamentSettings gameLogicTournamentSettings = new(inputHandler);

--- a/TiKiTuTo/View/ConsoleView.cs
+++ b/TiKiTuTo/View/ConsoleView.cs
@@ -18,22 +18,76 @@ namespace TiKiTuTo.View
             Console.CursorVisible = false;
         }
 
+        /// <summary>
+        /// Shows Main Menu using standard console
+        /// </summary>
+        public void ShowMainMenu() { }
+        //{
+        //    Console.Clear();
+        //    Console.WriteLine(" -----------------------");
+        //    Console.WriteLine(" |     TiKiTuTo        | ");
+        //    Console.WriteLine(" -----------------------");
+        //    Console.WriteLine(" -------Main Menu-------");
+        //    Console.WriteLine(" -----------------------");
+        //    Console.WriteLine("1. Start New Tournament");
+        //    Console.WriteLine("2. Resume Earlier Tournament");
+        //    Console.WriteLine("3. Show Results Of Earlier Tournament");
+        //    Console.WriteLine("4. Manage Tournament Configurations");
+        //    Console.WriteLine("5. Exit Application");
 
-        public void ShowMainMenu()
+        //    WriteEmptyLine();
+        //}
+
+        public int MainMenuSelection()
         {
-            Console.Clear();
-            Console.WriteLine(" -----------------------");
-            Console.WriteLine(" |     TiKiTuTo        | ");
-            Console.WriteLine(" -----------------------");
-            Console.WriteLine(" -------Main Menu-------");
-            Console.WriteLine(" -----------------------");
-            Console.WriteLine("1. Start New Tournament");
-            Console.WriteLine("2. Resume Earlier Tournament");
-            Console.WriteLine("3. Show Results Of Earlier Tournament");
-            Console.WriteLine("4. Manage Tournament Configurations");
-            Console.WriteLine("5. Exit Application");
+            
+            List<string> headerLines = new()
+            {
+                " -----------------------",
+                " |     TiKiTuTo        |",
+                " -----------------------",
+                " -------Main Menu-------",
+                " -----------------------"
+            }; 
 
-            WriteEmptyLine();
+            List<string> options = new()
+            {
+            "Start New Tournament",
+            "Resume Earlier Tournament",
+            "Show Results Of Earlier Tournament",
+            "Manage Tournament Configurations",
+            "Exit Application"
+            };
+
+            int userChoice = PromptSelectionMulti(headerLines, options);
+
+            return userChoice;
+        }
+
+
+
+        public int StartTournamentMenuSelection()
+        {
+            List<string> headerLines = new()
+            {
+                " -----------------------",
+                " |     TiKiTuTo        |",
+                " -----------------------",
+                " ---Start Tournament----",
+                " -----------------------"
+            };
+
+            List<string> options = new()
+            {
+            "Start tournament from scratch",
+            "Start tournament based on existing tournament settings",
+            "Back to Main Menu",
+            };
+
+            int userChoice = PromptSelectionMulti(headerLines, options);
+
+            return userChoice;
+
         }
 
         public void ShowStartTournamentMenu()
@@ -137,6 +191,28 @@ namespace TiKiTuTo.View
             return userChoice;
         }
 
+
+
+
+        public int PromptSelectionMulti(IEnumerable<string> headerLines, IEnumerable<string> options)
+        {
+            AnsiConsole.Clear();
+            
+            foreach (string line in headerLines)
+            {
+                AnsiConsole.MarkupLine($"[yellow]{line}[/]");
+            }
+            var userChoice = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("[yellow]Please select an option:[/]")
+                    .PageSize(5)
+                    .AddChoices(options));
+            
+            return options.ToList().IndexOf(userChoice) + 1;
+        }
+
+
+
         //hardcoded ShowMenu functionality in case we do not use PromptSelection
         public string ShowSpectreMenu()
         {
@@ -152,8 +228,6 @@ namespace TiKiTuTo.View
                         "   5: Exit"));
             return userChoice;
         }
-
-        
 
 
     }

--- a/TiKiTuTo/View/ConsoleView.cs
+++ b/TiKiTuTo/View/ConsoleView.cs
@@ -65,6 +65,20 @@ namespace TiKiTuTo.View
         }
 
 
+        public void ShowStartTournamentMenu() { }
+        //{
+        //    Console.Clear();
+        //    Console.WriteLine(" ----------------------");
+        //    Console.WriteLine(" |     TiKiTuTo        | ");
+        //    Console.WriteLine(" ----------------------");
+        //    Console.WriteLine(" ---Start Tournament---");
+        //    Console.WriteLine(" ----------------------");
+        //    Console.WriteLine("1. Start tournament from scratch");
+        //    Console.WriteLine("2. Start tournament based on existing tournament settings");
+        //    Console.WriteLine("3. Back to Main Menu");
+        //    WriteEmptyLine();
+        //}
+
 
         public int StartTournamentMenuSelection()
         {
@@ -90,19 +104,29 @@ namespace TiKiTuTo.View
 
         }
 
-        public void ShowStartTournamentMenu()
+        public int SavedTournamentsSelection(IEnumerable<string> loadableFiles)
         {
-            Console.Clear();
-            Console.WriteLine(" ----------------------");
-            Console.WriteLine(" |     TiKiTuTo        | ");
-            Console.WriteLine(" ----------------------");
-            Console.WriteLine(" ---Start Tournament---");
-            Console.WriteLine(" ----------------------");
-            Console.WriteLine("1. Start tournament from scratch");
-            Console.WriteLine("2. Start tournament based on existing tournament settings");
-            Console.WriteLine("3. Back to Main Menu");
-            WriteEmptyLine();
+            List<string> headerLines = new()
+            {
+                "-----------------------",
+                "|     TiKiTuTo        |",
+                "-----------------------",
+                "---Saved Tournaments---",
+                "-----------------------"
+            };
+
+            List<string> options = loadableFiles.ToList();
+            options.Add("Back to Main Menu");
+
+
+            int userChoice = PromptSelectionMulti(headerLines, options);
+
+            return userChoice;
+
         }
+
+
+
 
 
         public void ShowInvalidInputMessage()

--- a/TiKiTuTo/View/ConsoleView.cs
+++ b/TiKiTuTo/View/ConsoleView.cs
@@ -168,6 +168,32 @@ namespace TiKiTuTo.View
             // TODO: Implement functionality for showing the next match
         }
 
+        public int ShowIngameMenu()
+        {
+            {
+                List<string> headerLines = new()
+            {
+                " -----------------------",
+                " |     TiKiTuTo        |",
+                " -----------------------",
+                " ----Quick Settings-----",
+                " -----------------------"
+            };
+
+                List<string> options = new()
+            {
+            "Save current Tournament",
+            "Back to Main Menu",
+            "Exit and Save.",
+            };
+
+                int userChoice = PromptSelectionMulti(headerLines, options);
+
+                return userChoice;
+
+            }
+        }
+
 
         public void ShowMessage(string message)
         {

--- a/TiKiTuTo/View/IView.cs
+++ b/TiKiTuTo/View/IView.cs
@@ -21,6 +21,8 @@ namespace TiKiTuTo.View
 
         public void ShowStartTournamentMenu();
 
+        public int ShowIngameMenu();
+
         public void ShowInvalidInputMessage();
 
         public void ShowExitMessage();

--- a/TiKiTuTo/View/IView.cs
+++ b/TiKiTuTo/View/IView.cs
@@ -9,6 +9,11 @@ namespace TiKiTuTo.View
 {
     public interface IView
     {
+
+        public int MainMenuSelection();
+
+        public int StartTournamentMenuSelection();
+
         public void ShowMainMenu();
 
         public void ShowStartTournamentMenu();

--- a/TiKiTuTo/View/IView.cs
+++ b/TiKiTuTo/View/IView.cs
@@ -9,11 +9,14 @@ namespace TiKiTuTo.View
 {
     public interface IView
     {
-
+        //Methods which directly return user input 
         public int MainMenuSelection();
 
         public int StartTournamentMenuSelection();
 
+        public int SavedTournamentsSelection(IEnumerable<string> loadableFiles);
+
+        //Methods which simply show things
         public void ShowMainMenu();
 
         public void ShowStartTournamentMenu();
@@ -41,8 +44,6 @@ namespace TiKiTuTo.View
         public string PromptSelection(string title, IEnumerable<string> options);
 
         public string ShowSpectreMenu();
-
-
-
+        
     }
 }


### PR DESCRIPTION
combining statemachine efforts

added stubs to handle dynamic menus (variable number of menu points) -> needs to be translated to Spectre methods

renamed RenderCurrentState to ExecuteCurrentState

added all 12 cases (so far) in ExecuteCurrentState and in HandleUserInput

- added stubs for JSONService:
         GetFinishedTournamentFiles
         GetUnfinishedTournamentFiles
(used to create dynamic menus)
